### PR TITLE
openlens: Update docsUrl to point to non-404 location.

### DIFF
--- a/automatic/openlens/openlens.nuspec
+++ b/automatic/openlens/openlens.nuspec
@@ -44,7 +44,7 @@ This is a nuspec. It mostly adheres to https://docs.microsoft.com/en-us/nuget/re
     <releaseNotes>https://github.com/lensapp/lens/releases/tag/v6.2.1</releaseNotes>
     <licenseUrl>https://github.com/lensapp/lens/blob/master/LICENSE</licenseUrl>
     <packageSourceUrl>https://github.com/virtualex-itv/chocolatey-packages/tree/master/automatic/openlens</packageSourceUrl>
-    <docsUrl>https://docs.k8slens.dev/main/</docsUrl>
+    <docsUrl>https://docs.k8slens.dev/</docsUrl>
     <summary>The Kubernetes IDE - Open Source Project</summary>
     <description><![CDATA[OpenLens is the only IDE you'll ever need to take control of your Kubernetes clusters.  OpenLens is open source and free.
 


### PR DESCRIPTION
Update the `docsUrl` for the `openlens` package to point to a non-404 location.

## Description
Update the `docsUrl` for the `openlens` package to point to a non-404 location. The current URL returns `404` which confusing to Chocolatey's automated package validation; there is a redirect at the invalid URL to point to the correct URL but the redirection is done via Javascript and Chocolatey's automated package validation isn't able to follow the redirect.

## Motivation and Context
Ensure that `openlens` downloads on `chocolatey.org` aren't shown as waiting for maintainer.

## How Has this Been Tested?
N/A

## Screenshot (if appropriate, usually isn't needed):
N/A

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [X] The changes only affect a single package (not including meta package).
