### PR TITLE
Updated manifest for RVTools v4.6.1 (released on May 14th 2024)

### DIFF
--- a/automatic/rvtools/rvtools.nuspec
+++ b/automatic/rvtools/rvtools.nuspec
@@ -26,7 +26,7 @@ This is a nuspec. It mostly adheres to https://docs.microsoft.com/en-us/nuget/re
     <!-- version should MATCH as closely as possible with the underlying software -->
     <!-- Is the version a prerelease of a version? https://docs.microsoft.com/en-us/nuget/concepts/package-versioning#creating-prerelease-packages -->
     <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
-    <version>4.5.1.20240226</version>
+    <version>4.6.1</version>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>virtualex</owners>
     <!-- ============================== -->
@@ -34,17 +34,17 @@ This is a nuspec. It mostly adheres to https://docs.microsoft.com/en-us/nuget/re
     <!-- == SOFTWARE SPECIFIC SECTION == -->
     <!-- This section is about the software itself -->
     <title>RVTools</title>
-    <authors>Rob de Veij</authors>
+    <authors>Dell</authors>
     <!-- projectUrl is required for the community feed -->
     <projectUrl>https://robware.net/</projectUrl>
     <iconUrl>https://rawcdn.githack.com/virtualex-itv/chocolatey-packages/2dcfd72797ad9ed0ce34c5450962910ce1c146df/icons/rvtools.png</iconUrl>
     <!-- copyright is usually years and software vendor, but not required for internal feeds -->
-    <copyright>Copyright © 2024 Robware</copyright>
+    <copyright>Copyright © 2024 Dell Technologies</copyright>
     <tags>rvtools admin vmware vsphere esx esxi utility</tags>
     <releaseNotes>https://www.robware.net/versionInfo</releaseNotes>
     <licenseUrl>https://www.robware.net/download</licenseUrl>
     <packageSourceUrl>https://github.com/virtualex-itv/chocolatey-packages/tree/master/automatic/rvtools</packageSourceUrl>
-    <docsUrl>https://www.robware.net/resources/RVTools.pdf</docsUrl>
+    <docsUrl>https://fdendpoint-tf-ae40cce298ca76ff-prod-a2bhbrbte7exh5d4.a01.azurefd.net/resources/prod/RVTools.pdf</docsUrl>
     <summary>RVTools is a Windows .NET 4.6.1 application which uses VMware vSphere Management SDK 8.0 and CIS REST API to display information about your virtual environments.</summary>
     <description><![CDATA[**Note**: In October 2023, Dell Technologies acquired RVTools technology. Dell is committed to keeping RVTools available as a no cost public download, so it can continue to be an open asset for the technical community.
 

--- a/automatic/rvtools/tools/chocolateyinstall.ps1
+++ b/automatic/rvtools/tools/chocolateyinstall.ps1
@@ -2,8 +2,8 @@
 
 $toolsDir               = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
-$url                    = 'https://robware.net/resources/RVTools4.5.1.msi'
-$checksum               = 'ab9a4edc0c9b703a6df11debf41553dc6ebd050efa4da630645125909d641db8'
+$url                    = 'https://fdendpoint-tf-ae40cce298ca76ff-prod-a2bhbrbte7exh5d4.a01.azurefd.net/resources/prod/RVTools4.6.1.msi'
+$checksum               = '1eaab4a563201384761b2fdf9c7dd0de4d8be2cef8db1faf386279ea4de8c08d'
 $checksumType           = 'sha256'
 
 $packageArgs = @{


### PR DESCRIPTION
Manifest updates (including version, download URLs)