### PR TITLE
fix(garmin-express): use correct SHA256 hash of installer

### DIFF
--- a/automatic/garmin-express/tools/chocolateyInstall.ps1
+++ b/automatic/garmin-express/tools/chocolateyInstall.ps1
@@ -7,7 +7,7 @@ $packageArgs = @{
   fileType      = "EXE"
   url           = "https://download.garmin.com/omt/express/GarminExpress.exe"
 
-  checksum      = 'f48f621133d5b158963e6048d521f881fa152d1f598b748bdaa229126a89352c'
+  checksum      = 'b9b82e864c32cc8f3934ef4bebf6e5939b884c0ef98af5fc7ff3314e7b5ba781'
 
   checksumType  = 'sha256'
   silentArgs    = '/quiet /norestart'


### PR DESCRIPTION
At the moment, the installation of `v7.28.0` fails with:
```shell
ERROR: Checksum for 'D:\Development\PackageCaches\Chocolatey\garmin-express\7.28.0\GarminExpress.exe' did not meet 'f48f621133d5b158963e6048d521f881fa152d1f598b748bdaa229126a89352c' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The upgrade of garmin-express was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\garmin-express\tools\chocolateyInstall.ps1'.
 See log for details.
```

<!-- Provide a general summary of your changes in the Title above, prefixed with (packageName) -->

## Description
I've downloaded Garmin Express and calculated the SHA256 hash via `(Get-FileHash "C:\Users\Mirko\Documents\Downloads\GarminExpress.exe" -Algorithm SHA256).Hash.ToLower()`.

## Motivation and Context
At the moment, the installation is broken.

## How Has this Been Tested?
`choco pack` → `choco install garmin-express --source my-local-folder -y`

## Screenshot (if appropriate, usually isn't needed):
/

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Migrated package (a package has been migrated from another repository)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this repository.
- [ ] My change requires a change to documentation (this usually means the notes in the description of a package).
- [ ] I have updated the documentation accordingly (this usually means the notes in the description of a package).
- [ ] All files are up to date with the latest [Contributing Guidelines](https://github.com/mkevenaar/chocolatey-packages/blob/master/CONTRIBUTING.md)
- [ ] The added/modified package passed install/uninstall in the chocolatey test environment.
- [x] The changes only affect a single package (not including meta package).
